### PR TITLE
[Dev] Add feature flag for Recaptcha

### DIFF
--- a/components/sections/ContactSection.tsx
+++ b/components/sections/ContactSection.tsx
@@ -50,7 +50,10 @@ export default function ContactSection(): JSX.Element {
         try {
           const body: FormData = new FormData(event.currentTarget)
 
-          if (process.env.NODE_ENV === 'production') {
+          if (
+            process.env.NEXT_PUBLIC_FEATURE_ENABLED_RECAPTCHA &&
+            process.env.NODE_ENV === 'production'
+          ) {
             const recaptchaToken: string = await grecaptcha.enterprise.execute(
               process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY,
               {
@@ -119,12 +122,13 @@ export default function ContactSection(): JSX.Element {
 
   return (
     <Section name="contact">
-      {process.env.NODE_ENV === 'production' && (
-        <Script
-          src={`https://www.google.com/recaptcha/enterprise.js?render=${process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY}`}
-          onLoad={() => grecaptcha.enterprise.ready(() => setLoading(false))}
-        />
-      )}
+      {process.env.NEXT_PUBLIC_FEATURE_ENABLED_RECAPTCHA &&
+        process.env.NODE_ENV === 'production' && (
+          <Script
+            src={`https://www.google.com/recaptcha/enterprise.js?render=${process.env.NEXT_PUBLIC_RECAPTCHA_SITE_KEY}`}
+            onLoad={() => grecaptcha.enterprise.ready(() => setLoading(false))}
+          />
+        )}
 
       <div className={styles['section-header']}>
         <h2>Contact</h2>

--- a/enviroment.d.ts
+++ b/enviroment.d.ts
@@ -3,6 +3,7 @@ declare global {
     interface ProcessEnv {
       GOOGLE_CLOUD_API_KEY: string
       GOOGLE_CLOUD_PROJECT_ID: string
+      NEXT_PUBLIC_FEATURE_ENABLED_RECAPTCHA: string
       NEXT_PUBLIC_RECAPTCHA_SITE_KEY: string
       RECAPTCHA_SECRET_KEY: string
     }

--- a/utils/Recaptcha.ts
+++ b/utils/Recaptcha.ts
@@ -18,7 +18,11 @@ export const verify = async (
   recpatchaToken: FormDataEntryValue | null,
   expectedAction: string
 ): Promise<Api.Recaptcha.ErrorResponse> => {
-  if (process.env.NODE_ENV !== 'production') return
+  if (
+    !process.env.NEXT_PUBLIC_FEATURE_ENABLED_RECAPTCHA ||
+    process.env.NODE_ENV !== 'production'
+  )
+    return
 
   if (!recpatchaToken || typeof recpatchaToken !== 'string')
     return NextResponse.json(


### PR DESCRIPTION
Adds a feature flag (`NEXT_PUBLIC_FEATURE_ENABLED_RECAPTCHA`) which must be enabled to support reCaptcha.

There is currently an issue that prevents reCaptcha from validating on production deployments. This will allow us to temporarily disable reCaptcha until we can sort out the problem.