### PR TITLE
[Bug] Potential iOS cutoff issue

### DIFF
--- a/utils/useNoPageScroll.tsx
+++ b/utils/useNoPageScroll.tsx
@@ -13,6 +13,10 @@ export function useNoPageScroll(): void {
         body,
         :root {
           overflow: hidden;
+
+          min-height: 100svh;
+          height: 100svh;
+          max-height: 100svh;
         }
       `)
     }


### PR DESCRIPTION
Previously the bottom of the /tarot route (and potentially a few others) was having its content cutoff and hidden, in this case preventing the use of the buttons to draw cards.

This switches the html/body elements over to using svh units instead of percentages which will hopefully fix the issue. However, I am unable to test currently on a live device so this is just a push and hope it fixes it, though it can't make the issue any worse, so no issues there.